### PR TITLE
Set docker image's default command to run main.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the current directory contents into the container at /app
 COPY . .
+
+# Set default container start command
+CMD ["python3", "main.py"]


### PR DESCRIPTION
# Description
Sets the default container execution command to start the DiscordGSM service.

# Fixes/Changes
This pr/commit adds the "python3 main.py" command as the default command for the container so the container no longer defaults into an empty python shell (default behavior of the extended python docker image) and now starts DiscordGSM

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes