### PR TITLE
Updated So REST API Will Work With Bot

### DIFF
--- a/discordgsm/protocols/palworld.py
+++ b/discordgsm/protocols/palworld.py
@@ -1,4 +1,4 @@
-import os
+import base64
 import time
 from typing import TYPE_CHECKING
 
@@ -14,32 +14,73 @@ if TYPE_CHECKING:
 class Palworld(Protocol):
     name = "palworld"
 
-    async def query(self):
+    def __init__(self):
+        super().__init__()
+        self.server_name = None  # Attribute to store the server name
+
+    async def query(self, password: str):
+        """Query Palworld server with REST API using Base64 authentication (username: 'admin')"""
+        
+        # Username is fixed as 'admin'
+        username = 'admin'
+        
+        # Get host and port from the kv dictionary
         host, port = str(self.kv["host"]), int(str(self.kv["port"]))
+        
+        # Resolve the host to an IP address
         ip = await Socket.gethostbyname(host)
 
-        base_url = os.getenv('OPENGSQ_MASTER_SERVER_URL', 'https://master-server.opengsq.com/').rstrip('/')
-        url = f"{base_url}/palworld/search?host={ip}&port={port}"
-        start = time.time()
+        # Base64 encode 'admin:password' credentials
+        credentials = f'{username}:{password}'
+        encoded_credentials = base64.b64encode(credentials.encode('ascii'))
 
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url) as response:
-                response.raise_for_status()
-                data: dict = await response.json()
-                ping = int((time.time() - start) * 1000)
-
-        result: GamedigResult = {
-            "name": data.get("name", ""),
-            "map": data.get("map_name", ""),
-            "password": data.get("is_password", False),
-            "numplayers": data.get("current_players", 0),
-            "numbots": 0,
-            "maxplayers": data.get("max_players", 0),
-            "players": None,
-            "bots": None,
-            "connect": f"{host}:{port}",
-            "ping": ping,
-            "raw": data,
+        # Build the URL to query the server info
+        url = f"http://{ip}:{port}/v1/api/info"
+        
+        # Define request headers
+        headers = {
+            'Authorization': f'Basic {encoded_credentials}',
+            'Accept': 'application/json'
         }
 
-        return result
+        # Log the start time for calculating ping
+        start = time.time()
+
+        # Query the server info using aiohttp
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(url, headers=headers) as response:
+                    response.raise_for_status()  # Raise an error for non-2xx responses
+                    data = await response.json()  # Parse the JSON response
+                    ping = int((time.time() - start) * 1000)
+
+                    # Extract and auto-fill the server name
+                    self.server_name = data.get("servername", "Unknown Server")
+
+                    # Force the status to 'online' if server name is present
+                    if self.server_name and self.server_name != "Unknown Server":
+                        status = "online"
+                    else:
+                        status = "offline"
+
+                    # Return the server result
+                    result: GamedigResult = {
+                        "status": status,  # Force online status if server name is available
+                        "name": self.server_name,  # Use the auto-filled server name
+                        "version": data.get("version", "Unknown Version"),
+                        "description": data.get("description", "No Description"),
+                        "map": data.get("map_name", ""),
+                        "password": data.get("is_password", False),
+                        "numplayers": data.get("current_players", 0),
+                        "numbots": 0,
+                        "maxplayers": data.get("max_players", 0),
+                        "players": None,
+                        "bots": None,
+                        "connect": f"{host}:{port}",
+                        "ping": ping,
+                        "raw": data,
+                    }
+                    return result
+            except Exception as e:
+                # Log and return the offline status if any exception occurs
+                return {"status": "offline", "error": str(e)}


### PR DESCRIPTION
First time coding something this i guess complicated since im self taught..this is assuming you have RESTAPIEnabled=True RESTAPIPort=8212
In your palwordsettings.ini
I hardcoded it so admin is the default username so when you do /addserver and it asks for ip port there will also be a box that says username:password only enter you admin password for your server. The reason why the box says username:password is because REST API uses BASE64 to encode your password to access stuff, so i set it up where you enter your password regurlarly and then the script will now the username is admin then take your password and encode it with base64 spit that code out into the script and then decode it to get access to the server then itll send the very basic comman curl -L -X GET 'http://localhost:8212/v1/api/info' \ -H 'Accept: application/json' \
-H 'Authorization: xxxxxxx

where your ip is what you entered in the pop up it then accepts the api application from palworld which asks for the authorization password which you entered and its converted...this is all i could figure out, i couldnt get it to work like the other servers with the fancy symbols and green buttons but hopefully the original person who created this will be able to edit what i did and pretty it up.