### PR TITLE
Doom 3 / Quake 4 Fix

### DIFF
--- a/discordgsm/protocols/doom3.py
+++ b/discordgsm/protocols/doom3.py
@@ -24,7 +24,7 @@ class Doom3(Protocol):
             "name": info.get("si_name", ""),
             "map": info.get("si_map", ""),
             "password": info.get("si_usepass", info.get("si_needPass", "0")) == 1,
-            "numplayers": int(status.players),
+            "numplayers": len(status.players),
             "numbots": 0,
             "maxplayers": int(
                 info.get("si_maxplayers", info.get("si_maxPlayers", "0"))


### PR DESCRIPTION
Fixes doom3.py to check the length of the players list, instead of trying to convert a list to an integer.