### PR TITLE
Add ETS2 support via source protocol

### DIFF
--- a/discordgsm/games.csv
+++ b/discordgsm/games.csv
@@ -101,6 +101,7 @@ empyrion,Empyrion - Galactic Survival (2015),source,port=30000;port_query_offset
 enshrouded,Enshrouded (2024),source,port=27015;port_query_offset=1
 esf,Half Life: Earths Special Forces(2013),source,port=27015
 etqw,Enemy Territory: Quake Wars (2007),doom3,port=3074;port_query=27733
+ets2,Euro Truck Simulator 2,source,port_query=27016
 exfil,EXFIL (2024),source,port_query=27015
 
 f12002,Formula One 2002 (2002),gamespy1,port_query=3297


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8fb0e005-a504-40f3-9d4e-f77d64fc3664)
As per title, add Euro Truck Simulator (ETS2) to games.csv using source protocol. Refer attached image of my test.
IP:Port to test: 129.150.44.22:27001
