### PR TITLE
Change Python Process to Non-Privileged User in Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use an official Python runtime as a parent image
 FROM python:3.13-alpine
 
+# Update the OS
+RUN apk update \
+  && apk upgrade
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -20,3 +24,11 @@ COPY . .
 
 # Set default container start command
 CMD ["python", "main.py"]
+
+# Create the non-privileged user
+RUN adduser -D gsm
+
+# Grant permissions to the logs directory
+RUN chown -R gsm:gsm /usr/src/app/data/logs
+
+USER gsm


### PR DESCRIPTION
Adds additional Docker image security:
- Updates the OS during image build.
- Adds a non-privileged runtime user to avoid running as root and reduce attack surface. This does require host-side permissions modification on the bind mount to ensure the container user has write access.